### PR TITLE
Fix build issues with newer compilers (GCC9/10)

### DIFF
--- a/bfd/elf-bfd.h
+++ b/bfd/elf-bfd.h
@@ -1911,7 +1911,7 @@ struct elf_obj_tdata
   struct sdt_note *sdt_note_head;
 
   Elf_Internal_Shdr **group_sect_ptr;
-  int num_group;
+  unsigned int num_group;
 
   /* Index into group_sect_ptr, updated by setup_group when finding a
      section's group.  Used to optimize subsequent group searches.  */

--- a/binutils/wrstabs.c
+++ b/binutils/wrstabs.c
@@ -1440,18 +1440,15 @@ stab_end_struct_type (void *p)
 /* Start outputting a class.  */
 
 static bfd_boolean
-stab_start_class_type (void *p, const char *tag, unsigned int id, bfd_boolean structp, unsigned int size, bfd_boolean vptr, bfd_boolean ownvptr)
+stab_start_class_type (void *p, const char *tag, unsigned int id,
+		       bfd_boolean structp, unsigned int size,
+		       bfd_boolean vptr, bfd_boolean ownvptr)
 {
   struct stab_write_handle *info = (struct stab_write_handle *) p;
-  bfd_boolean definition;
-  char *vstring;
+  bfd_boolean definition = FALSE;
+  char *vstring = NULL;
 
-  if (! vptr || ownvptr)
-    {
-      definition = FALSE;
-      vstring = NULL;
-    }
-  else
+  if (vptr && !ownvptr)
     {
       definition = info->type_stack->definition;
       vstring = stab_pop_type (info);
@@ -1472,16 +1469,15 @@ stab_start_class_type (void *p, const char *tag, unsigned int id, bfd_boolean st
 	}
       else
 	{
+	  assert (vstring);
 	  vtable = (char *) xmalloc (strlen (vstring) + 3);
 	  sprintf (vtable, "~%%%s", vstring);
 	  free (vstring);
+	  if (definition)
+	    info->type_stack->definition = TRUE;
 	}
-
       info->type_stack->vtable = vtable;
     }
-
-  if (definition)
-    info->type_stack->definition = TRUE;
 
   return TRUE;
 }


### PR DESCRIPTION
Newer compilers generate an error on two warnings while compiling this binutils version. There are patches available for both cases, which I have applied. I am using GCC 10.1.0. 

It might be better to rebase onto a newer version of binutils, but I figured that too much work.

The hermit toolchain builds fine with these changes together with the updated toolchain.sh from https://github.com/hermitcore/hermit-toolchain/pull/3 